### PR TITLE
update clusterrole to rbac.authorization.k8s.io/v1 (k8s 1.22 API depr…

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "k8s-event-logger.fullname" . }}
   labels:


### PR DESCRIPTION
see https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122, the ClusterRoleBinding is already `rbac.authorization.k8s.io/v1`