### PR TITLE
Build an arm64 container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.18.3 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.18.3 as builder
+ARG TARGETARCH
+ARG TARGETOS
 WORKDIR /go/src/github.com/max-rocket-internet/k8s-event-logger
 COPY . .
 RUN go get
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o k8s-event-logger
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o k8s-event-logger
 RUN adduser --disabled-login --no-create-home --disabled-password --system --uid 101 non-root
 
-FROM alpine:3.15.4
+FROM --platform=${TARGETPLATFORM} alpine:3.15.4
 RUN addgroup -S non-root && adduser -S -G non-root non-root
 USER 101
 ENV USER non-root

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+VERSION ?= 1.6.1
+IMG ?= maxrocketinternet/k8s-event-logger:$(VERSION)
+
+.PHONY: image
+
+image:
+	docker buildx build --platform linux/amd64,linux/arm64 --push -t $(IMG) .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-VERSION ?= 1.6.1
-IMG ?= maxrocketinternet/k8s-event-logger:$(VERSION)
+IMG ?= maxrocketinternet/k8s-event-logger
+TAG ?= 1.6
+PLATFORMS ?= linux/amd64,linux/arm64
 
 .PHONY: image
 
 image:
-	docker buildx build --platform linux/amd64,linux/arm64 --push -t $(IMG) .
+	docker buildx build --platform $(PLATFORMS) --push -t $(IMG):$(TAG) .

--- a/README.md
+++ b/README.md
@@ -38,7 +38,22 @@ Use the [Helm](https://helm.sh/) chart:
 helm install chart/
 ```
 
-Or user the docker image [maxrocketinternet/k8s-event-logger](https://hub.docker.com/r/maxrocketinternet/k8s-event-logger)
+Or use the docker image [maxrocketinternet/k8s-event-logger][image]
+
+[image]: https://hub.docker.com/r/maxrocketinternet/k8s-event-logger
+
+#### Building a container image
+
+If you're unable to use the [prebuilt][image] docker image, you can build it yourself:
+
+```sh
+make IMG=your.docker.registry/k8s-event-logger image
+```
+
+This uses `docker buildx` to create a [multi-platform image][]. To set up your build host system to be able to build these images, see [this guide][qemu-binfmt].
+
+[multi-platform image]: https://docs.docker.com/build/building/multi-platform/
+[qemu-binfmt]: https://docs.nvidia.com/datacenter/cloud-native/playground/x-arch.html
 
 ### Testing
 


### PR DESCRIPTION
👋🏻 Hello! Thank you for this project. 😄 I’m going to be deploying this to my clusters at work, but I need to run it on arm64 nodes.

This updates the `Dockerfile` to support [cross-compiling the Go binary](https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/) to a different target platform, and adds a `Makefile` which uses [docker buildx](https://docs.docker.com/build/buildx/multiplatform-images/) to create `amd64` and `arm64` images and a multi-arch image manifest to tie them together.

If you’ve not built multi-architecture images before, [this guide](https://docs.nvidia.com/datacenter/cloud-native/playground/x-arch.html) is a good starting point for what needs to be set up on the host system.