### PR TITLE
Upgrade alpine base image version to 3.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go get
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o k8s-event-logger
 RUN adduser --disabled-login --no-create-home --disabled-password --system --uid 101 non-root
 
-FROM --platform=${TARGETPLATFORM} alpine:3.15.4
+FROM --platform=${TARGETPLATFORM} alpine:3.18.0
 RUN addgroup -S non-root && adduser -S -G non-root non-root
 USER 101
 ENV USER non-root


### PR DESCRIPTION
To minimize severity vulnerability in the container image, we should upgrade to the latest apline base image.  

<img width="1467" alt="Screenshot 2023-06-03 at 02 41 47" src="https://github.com/max-rocket-internet/k8s-event-logger/assets/1296554/fa0eb12e-37bf-47a5-a7a3-2d40dc70e679">
