### PR TITLE
Updated base image to be from scratch instead of alpine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+
+# Go workspace file
+go.work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM --platform=${BUILDPLATFORM} golang:1.18.3 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.20.5 as builder
 ARG TARGETARCH
 ARG TARGETOS
 WORKDIR /go/src/github.com/max-rocket-internet/k8s-event-logger
 COPY . .
-RUN go get
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o k8s-event-logger
-RUN adduser --disabled-login --no-create-home --disabled-password --system --uid 101 non-root
+RUN go mod vendor
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o k8s-event-logger &&\
+    if ldd 'k8s-event-logger'; then exit 1; fi; # Ensure binary is statically-linked
+RUN echo "k8s-event-logger:x:10001:10001::/:/bin/false" > /etc_passwd_to_copy
 
-FROM --platform=${TARGETPLATFORM} alpine:3.18.0
-RUN addgroup -S non-root && adduser -S -G non-root non-root
-USER 101
-ENV USER non-root
-COPY --from=builder /go/src/github.com/max-rocket-internet/k8s-event-logger/k8s-event-logger k8s-event-logger
-CMD ["/k8s-event-logger"]
+FROM --platform=${TARGETPLATFORM} scratch
+COPY --from=builder /etc_passwd_to_copy /go/src/github.com/max-rocket-internet/k8s-event-logger/k8s-event-logger /
+ENV USER=k8s-event-logger
+USER 10001
+ENTRYPOINT ["/k8s-event-logger"]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,27 @@
 IMG ?= maxrocketinternet/k8s-event-logger
-TAG ?= 1.6
+TAG ?= 1.9
 PLATFORMS ?= linux/amd64,linux/arm64
+BUILDXDRIVER ?= docker-container
+WITHSBOM ?= true
+
+.DEFAULT_GOAL := image
+
+.PHONY: all
+all: binfmt buildxbuilder image
+
+.PHONY: binfmt
+binfmt:
+	docker run --privileged --rm tonistiigi/binfmt --install all
+
+.PHONY: buildxbuilder
+buildxbuilder:
+	docker buildx create --name k8s-event-logger-builder --driver $(BUILDXDRIVER) --platform $(PLATFORMS) --bootstrap
 
 .PHONY: image
-
 image:
-	docker buildx build --platform $(PLATFORMS) --push -t $(IMG):$(TAG) .
+	docker buildx build --builder k8s-event-logger-builder --platform $(PLATFORMS) --sbom=$(WITHSBOM) --push -t $(IMG):$(TAG) .
+
+.PHONY: clean
+clean:
+	-docker rmi $(IMG):$(TAG)
+	-docker buildx rm k8s-event-logger-builder


### PR DESCRIPTION
Added post-build check to guarantee statically linked binary
Updated builder container to use golang:1.20.5
Changed CMD to ENTRYPOINT as this is a single executable container with no arguments
Updated Makefile to setup a build multi-arch docker system if desired and TAG default to 1.9
Updated the docker buildx command to generate an sbom during build.
Added .gitignore