### PR TITLE
Better kubernetes configuration detection based on k8s libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ COPY . .
 RUN go mod vendor
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o k8s-event-logger &&\
     if ldd 'k8s-event-logger'; then exit 1; fi; # Ensure binary is statically-linked
-RUN echo "k8s-event-logger:x:10001:10001::/:/bin/false" > /etc_passwd_to_copy
 
 FROM --platform=${TARGETPLATFORM} scratch
-COPY --from=builder /etc_passwd_to_copy /go/src/github.com/max-rocket-internet/k8s-event-logger/k8s-event-logger /
-ENV USER=k8s-event-logger
+COPY --from=builder /go/src/github.com/max-rocket-internet/k8s-event-logger/k8s-event-logger /
 USER 10001
 ENTRYPOINT ["/k8s-event-logger"]

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -33,16 +33,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 10001
-            runAsGroup: 10001
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
+            {{- toYaml .Values.securityContext | nindent 12 }}
           env:
 {{- range $key, $value := .Values.env }}
           - name: {{ $key }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,10 +11,7 @@ resources:
     cpu: 100m
     memory: 128Mi
 
-env:
-  KUBERNETES_API_URL: https://172.20.0.1:443
-  CA_FILE: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-
+env: {}
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -23,3 +20,14 @@ tolerations: []
 affinity: {}
 podLabels: {}
 podAnnotations: {}
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"os"
-	"os/user"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -19,34 +17,26 @@ func main() {
 	loggerApplication := log.New(os.Stderr, "", log.LstdFlags)
 	loggerEvent := log.New(os.Stdout, "", 0)
 
-	usr, err := user.Current()
+	var err error
+	var config *rest.Config
+
+	// Using First sample from https://pkg.go.dev/k8s.io/client-go/tools/clientcmd to automatically deal with environment variables and default file paths
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// if you want to change the loading rules (which files in which order), you can do so here
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	config, err = kubeConfig.ClientConfig()
 	if err != nil {
 		loggerApplication.Panicln(err.Error())
 	}
 
-	var config *rest.Config
-
-	if k8s_port := os.Getenv("KUBERNETES_PORT"); k8s_port == "" {
-		loggerApplication.Println("Using local kubeconfig")
-		var kubeconfig string
-		home := usr.HomeDir
-		if home != "" {
-			kubeconfig = fmt.Sprintf("%s/.kube/config", home)
-		} else {
-			loggerApplication.Panicln("home directory unknown")
-		}
-
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-		if err != nil {
-			loggerApplication.Panicln(err.Error())
-		}
-	} else {
-		loggerApplication.Println("Using in-cluster authentication")
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			loggerApplication.Panicln(err.Error())
-		}
-	}
+	// Note that this *should* automatically sanitize sensitive fields
+	loggerApplication.Println("Using configuration:", config.String())
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -16,9 +15,6 @@ import (
 func main() {
 	loggerApplication := log.New(os.Stderr, "", log.LstdFlags)
 	loggerEvent := log.New(os.Stdout, "", 0)
-
-	var err error
-	var config *rest.Config
 
 	// Using First sample from https://pkg.go.dev/k8s.io/client-go/tools/clientcmd to automatically deal with environment variables and default file paths
 
@@ -30,7 +26,7 @@ func main() {
 
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
-	config, err = kubeConfig.ClientConfig()
+	config, err := kubeConfig.ClientConfig()
 	if err != nil {
 		loggerApplication.Panicln(err.Error())
 	}


### PR DESCRIPTION
Please test this locally (go run ./main.go) and in a k8s cluster both with a .kube/config with no KUBECONFIG env variable set and one with a KUBECONFIG env variable set before merging. It works for me, but I want to ensure it doesn't break anyone.

Instead of doing our own user home directory detection for .kube/config, use the k8s.io/cmdclient built-in methods which support KUBECONFIG env variable, $HOME/.kube/config, and KUBERNETES_SERVICE env variables automatically.

Also print out a sanitized representation of the config at startup in case of misconfiguration.