### PR TITLE
Allow filtering out normal events

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				if (*ignoreNormal && obj.(corev1.Event).Type == corev1.EventTypeNormal) {
+				if (*ignoreNormal && obj.(*corev1.Event).Type == corev1.EventTypeNormal) {
 					return
 				}
 				j, _ := json.Marshal(obj)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -15,7 +16,13 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var (
+	ignoreNormal = flag.Bool("ignore_normal", false, "ignore events of the normal type, they can be noisy")
+)
+
 func main() {
+	flag.Parse()
+
 	loggerApplication := log.New(os.Stderr, "", log.LstdFlags)
 	loggerEvent := log.New(os.Stdout, "", 0)
 
@@ -65,6 +72,9 @@ func main() {
 		0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
+				if (*ignoreNormal && obj.(corev1.Event).Type == corev1.EventTypeNormal) {
+					return
+				}
 				j, _ := json.Marshal(obj)
 				loggerEvent.Printf("%s\n", string(j))
 			},

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	ignoreNormal = flag.Bool("ignore_normal", false, "ignore events of the normal type, they can be noisy")
+	ignoreNormal = flag.Bool("ignore-normal", false, "ignore events of type 'Normal' to reduce noise")
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 


### PR DESCRIPTION
# Description

Normal events can often be noisy, and for many use cases all we care about is Warning events.

That said, add the ability to only report non-normal events via a flag.

# Testing

Tested using a kube cluster, works as expected.