### PR TITLE
Allow flags config via chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "2.0"
+appVersion: "2.2"
 version: "1.2.1"
 description: A tool to log k8s events to stdout in JSON
 home: https://github.com/max-rocket-internet/k8s-event-logger

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "2.0"
-version: "1.2.0"
+version: "1.2.1"
 description: A tool to log k8s events to stdout in JSON
 home: https://github.com/max-rocket-internet/k8s-event-logger
 name: k8s-event-logger

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
           - name: {{ $key }}
             value: {{ $value | quote }}
 {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: maxrocketinternet/k8s-event-logger
-  tag: "2.0"
+  tag: "2.2"
   pullPolicy: IfNotPresent
 
 resources:
@@ -12,6 +12,7 @@ resources:
     memory: 128Mi
 
 env: {}
+args: []
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Update The Chart to Support the "[Allow filtering Out Normal Events Flag](https://github.com/max-rocket-internet/k8s-event-logger/commit/a12102d27144d72d75846b893744e30d8df9e806)".

Following is the output of the deployment template with values:
```
args:
  - "--ignore-normal=true"
```

The following is the deployment template :
```
---
# Source: k8s-event-logger/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-k8s-event-logger
  labels:
    app.kubernetes.io/name: k8s-event-logger
    helm.sh/chart: k8s-event-logger-1.2.1
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "2.2"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: k8s-event-logger
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: k8s-event-logger
        app.kubernetes.io/instance: release-name
    spec:
      serviceAccountName: release-name-k8s-event-logger
      containers:
        - name: app
          image: "maxrocketinternet/k8s-event-logger:2.2"
          imagePullPolicy: IfNotPresent
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
              - ALL
            readOnlyRootFilesystem: true
            runAsGroup: 10001
            runAsNonRoot: true
            runAsUser: 10001
            seccompProfile:
              type: RuntimeDefault
          env:
          args:
            - --ignore-normal=true
          resources:
            limits:
              cpu: 100m
              memory: 128Mi
            requests:
              cpu: 10m
              memory: 32Mi
```
