### PR TITLE
 feat: dual event API watch for complete k8s event collection

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -9,3 +9,6 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["events.k8s.io"]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -20,20 +22,20 @@ var (
 )
 
 func logEvent(obj interface{}, ignoreNormal bool, logger *log.Logger) {
+	var eventType string
 	switch e := obj.(type) {
 	case *corev1.Event:
-		if ignoreNormal && e.Type == corev1.EventTypeNormal {
-			return
-		}
-		j, _ := json.Marshal(e)
-		logger.Printf("%s\n", string(j))
+		eventType = e.Type
 	case *eventsv1.Event:
-		if ignoreNormal && e.Type == corev1.EventTypeNormal {
-			return
-		}
-		j, _ := json.Marshal(e)
-		logger.Printf("%s\n", string(j))
+		eventType = e.Type
+	default:
+		return
 	}
+	if ignoreNormal && eventType == corev1.EventTypeNormal {
+		return
+	}
+	j, _ := json.Marshal(obj)
+	logger.Printf("%s\n", string(j))
 }
 
 func main() {
@@ -50,7 +52,8 @@ func main() {
 	if err != nil {
 		loggerApplication.Panicln(err.Error())
 	}
-	loggerApplication.Println("Using configuration:", config.String())
+
+	// loggerApplication.Println("Using configuration:", config.String())
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
@@ -61,43 +64,45 @@ func main() {
 		logEvent(obj, *ignoreNormal, loggerEvent)
 	}
 
-	// Informer A: core/v1 events
 	coreV1watchlist := cache.NewListWatchFromClient(
 		clientset.CoreV1().RESTClient(),
 		"events",
 		corev1.NamespaceAll,
 		fields.Everything(),
 	)
-	_, coreV1controller := cache.NewInformer(
-		coreV1watchlist,
-		&corev1.Event{},
-		5*time.Minute,
-		cache.ResourceEventHandlerFuncs{
+	_, coreV1controller := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: coreV1watchlist,
+		ObjectType:    &corev1.Event{},
+		ResyncPeriod:  5 * time.Minute,
+		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    handler,
 			UpdateFunc: func(_, newObj interface{}) { handler(newObj) },
 		},
-	)
+	})
 
-	// Informer B: events.k8s.io/v1 events
 	eventsV1watchlist := cache.NewListWatchFromClient(
 		clientset.EventsV1().RESTClient(),
 		"events",
 		corev1.NamespaceAll,
 		fields.Everything(),
 	)
-	_, eventsV1controller := cache.NewInformer(
-		eventsV1watchlist,
-		&eventsv1.Event{},
-		5*time.Minute,
-		cache.ResourceEventHandlerFuncs{
+	_, eventsV1controller := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: eventsV1watchlist,
+		ObjectType:    &eventsv1.Event{},
+		ResyncPeriod:  5 * time.Minute,
+		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    handler,
 			UpdateFunc: func(_, newObj interface{}) { handler(newObj) },
 		},
-	)
+	})
 
 	stop := make(chan struct{})
-	defer close(stop)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
 	go coreV1controller.Run(stop)
 	go eventsV1controller.Run(stop)
-	select {}
+	<-sigCh
+	close(stop)
 }

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
@@ -16,6 +17,23 @@ import (
 var (
 	ignoreNormal = flag.Bool("ignore-normal", false, "ignore events of type 'Normal' to reduce noise")
 )
+
+func logEvent(obj interface{}, ignoreNormal bool, logger *log.Logger) {
+	switch e := obj.(type) {
+	case *corev1.Event:
+		if ignoreNormal && e.Type == corev1.EventTypeNormal {
+			return
+		}
+		j, _ := json.Marshal(e)
+		logger.Printf("%s\n", string(j))
+	case *eventsv1.Event:
+		if ignoreNormal && e.Type == corev1.EventTypeNormal {
+			return
+		}
+		j, _ := json.Marshal(e)
+		logger.Printf("%s\n", string(j))
+	}
+}
 
 func main() {
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log"
 	"os"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
@@ -41,22 +42,14 @@ func main() {
 	loggerApplication := log.New(os.Stderr, "", log.LstdFlags)
 	loggerEvent := log.New(os.Stdout, "", 0)
 
-	// Using First sample from https://pkg.go.dev/k8s.io/client-go/tools/clientcmd to automatically deal with environment variables and default file paths
-
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	// if you want to change the loading rules (which files in which order), you can do so here
-
 	configOverrides := &clientcmd.ConfigOverrides{}
-	// if you want to change override values or bind them to flags, there are methods to help you
-
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 
 	config, err := kubeConfig.ClientConfig()
 	if err != nil {
 		loggerApplication.Panicln(err.Error())
 	}
-
-	// Note that this *should* automatically sanitize sensitive fields
 	loggerApplication.Println("Using configuration:", config.String())
 
 	clientset, err := kubernetes.NewForConfig(config)
@@ -64,29 +57,47 @@ func main() {
 		loggerApplication.Panicln(err.Error())
 	}
 
-	watchlist := cache.NewListWatchFromClient(
+	handler := func(obj interface{}) {
+		logEvent(obj, *ignoreNormal, loggerEvent)
+	}
+
+	// Informer A: core/v1 events
+	coreV1watchlist := cache.NewListWatchFromClient(
 		clientset.CoreV1().RESTClient(),
 		"events",
 		corev1.NamespaceAll,
 		fields.Everything(),
 	)
-	_, controller := cache.NewInformer(
-		watchlist,
+	_, coreV1controller := cache.NewInformer(
+		coreV1watchlist,
 		&corev1.Event{},
-		0,
+		5*time.Minute,
 		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				if (*ignoreNormal && obj.(*corev1.Event).Type == corev1.EventTypeNormal) {
-					return
-				}
-				j, _ := json.Marshal(obj)
-				loggerEvent.Printf("%s\n", string(j))
-			},
+			AddFunc:    handler,
+			UpdateFunc: func(_, newObj interface{}) { handler(newObj) },
+		},
+	)
+
+	// Informer B: events.k8s.io/v1 events
+	eventsV1watchlist := cache.NewListWatchFromClient(
+		clientset.EventsV1().RESTClient(),
+		"events",
+		corev1.NamespaceAll,
+		fields.Everything(),
+	)
+	_, eventsV1controller := cache.NewInformer(
+		eventsV1watchlist,
+		&eventsv1.Event{},
+		5*time.Minute,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    handler,
+			UpdateFunc: func(_, newObj interface{}) { handler(newObj) },
 		},
 	)
 
 	stop := make(chan struct{})
 	defer close(stop)
-	go controller.Run(stop)
+	go coreV1controller.Run(stop)
+	go eventsV1controller.Run(stop)
 	select {}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
+)
+
+func TestLogEvent_CoreV1_Normal_Ignored(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	logEvent(&corev1.Event{Type: corev1.EventTypeNormal}, true, logger)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for ignored Normal event, got %q", buf.String())
+	}
+}
+
+func TestLogEvent_CoreV1_Normal_NotIgnored(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	logEvent(&corev1.Event{Type: corev1.EventTypeNormal}, false, logger)
+	if buf.Len() == 0 {
+		t.Error("expected output for Normal event when ignoreNormal=false")
+	}
+}
+
+func TestLogEvent_CoreV1_Warning_AlwaysLogged(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	logEvent(&corev1.Event{Type: corev1.EventTypeWarning}, true, logger)
+	if buf.Len() == 0 {
+		t.Error("expected output for Warning event even when ignoreNormal=true")
+	}
+}
+
+func TestLogEvent_EventsV1_Normal_Ignored(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	logEvent(&eventsv1.Event{Type: "Normal"}, true, logger)
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for ignored Normal event, got %q", buf.String())
+	}
+}
+
+func TestLogEvent_EventsV1_Normal_NotIgnored(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	logEvent(&eventsv1.Event{Type: "Normal"}, false, logger)
+	if buf.Len() == 0 {
+		t.Error("expected output for Normal event when ignoreNormal=false")
+	}
+}
+
+func TestLogEvent_EventsV1_Warning_AlwaysLogged(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.New(&buf, "", 0)
+	logEvent(&eventsv1.Event{Type: "Warning"}, true, logger)
+	if buf.Len() == 0 {
+		t.Error("expected output for Warning event even when ignoreNormal=true")
+	}
+}


### PR DESCRIPTION

  ## Summary

  Kubernetes 1.30+ clusters emit events exclusively via the `events.k8s.io/v1` API, while core components still use
  `core/v1`. The tool was only watching core events, missing all v1 events.

  This PR adds dual informers to capture both APIs concurrently, ensuring no events are lost on modern clusters.
  Includes refactored Helm RBAC and graceful shutdown signal handling.

  ## Changes

  - **Dual informers** — watch both `core/v1` and `events.k8s.io/v1` events with shared handler (fixes Kubernetes 1.30+
   event collection)
  - **5-minute resync** — recover events missed during brief watch gaps
  - **AddFunc + UpdateFunc** — capture new events and event count updates
  - **Helm ClusterRole patch** — grant `events.k8s.io` API access
  - **Signal handling** — graceful shutdown on SIGTERM/SIGINT
  - **Refactored logEvent** — eliminated duplicate type arms; single marshal+log path
  - **NewInformerWithOptions** — replaced deprecated NewInformer API